### PR TITLE
handle missing space in usd/cad macro

### DIFF
--- a/server/cp/macros/usd_to_cad.py
+++ b/server/cp/macros/usd_to_cad.py
@@ -14,7 +14,7 @@ CURRENCY_REGEX = re.compile(
 )
 
 CURRENCY_REGEX_FR = re.compile(
-    r'(^| |\b)(?P<num>[0-9]+(?P<decimal>\,[0-9]+)?)(?P<mil> millions?)? (?P<currency>[A-Z]+)?\$($|\b)',
+    r'(^| |\b)(?P<num>[0-9]+(?P<decimal>\,[0-9]+)?)(?P<mil> millions?)? ?(?P<currency>[A-Z]+)?\$($|\b)',
     re.MULTILINE,
 )
 

--- a/server/tests/macros/usd_to_cad_macro_test.py
+++ b/server/tests/macros/usd_to_cad_macro_test.py
@@ -50,6 +50,7 @@ class USD2CADMacroTestCase(unittest.TestCase):
             ' $200.': {'key': ' $200', 'repl': 'C$265.60'},
             '52,34 millions $': '69,51 millions C$',
             '52,34 $': '69,51 C$',
+            '2,24$': '2,97 C$',
         }
 
         item = {'body_html': '\n'.join(test.keys())}


### PR DESCRIPTION
eg `2,24$`

SDCP-76