### PR TITLE
Use preview for all renditions mapping. [SDCP-256]

### DIFF
--- a/server/cp/ingest/parser/ap.py
+++ b/server/cp/ingest/parser/ap.py
@@ -65,7 +65,7 @@ class CP_APMediaFeedParser(APMediaFeedParser):
 
     # use preview for all now
     RENDITIONS_MAPPING = {
-        'original': 'main',
+        'original': 'preview',
         'baseImage': 'preview',
         'viewImage': 'preview',
         'thumbnail': 'thumbnail',

--- a/server/cp/ingest/parser/ap.py
+++ b/server/cp/ingest/parser/ap.py
@@ -63,10 +63,9 @@ class CP_APMediaFeedParser(APMediaFeedParser):
     PROFILE_ID = 'Story'
     RELATED_ID = 'media-gallery'
 
-    # use preview for all now
     RENDITIONS_MAPPING = {
-        'original': 'preview',
-        'baseImage': 'preview',
+        'original': 'main',
+        'baseImage': 'main',
         'viewImage': 'preview',
         'thumbnail': 'thumbnail',
     }
@@ -201,6 +200,15 @@ class CP_APMediaFeedParser(APMediaFeedParser):
         if ap_item.get('type') == 'picture':
             self._parse_picture_metadata(data['data'], item)
 
+        if item.get('associations'):
+            for key, assoc in item.get('associations', {}).items():
+                if assoc.get('renditions'):
+                    for key, value in self.RENDITIONS_MAPPING.items():
+                        if value == 'main':
+                            href = assoc['renditions'].get(key, {}).get('href')
+                            assoc['renditions'][key]['href'] = href + '&apikey=' + \
+                                provider.get('config', {}).get('apikey') if '?' in href else \
+                                href + '?apikey=' + provider.get('config', {}).get('apikey')
         return item
 
     def _parse_stocks(self, organisations):


### PR DESCRIPTION
main always needs the API key to append in it href whereas preview and thumbnail don't need the API key to append in its href so that we can format the main by appending the API key in it. But then it will give us the original resolutions which we don't want for cp images because cp images resolutions should be around 500*400. Therefore we need a preview for original as well.