### PR TITLE
update build tools

### DIFF
--- a/client/.npmrc
+++ b/client/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
         "superdesk-planning": "github:superdesk/superdesk-planning#develop"
     },
     "devDependencies": {
-        "@superdesk/build-tools": "^1.0.13"
+        "@superdesk/build-tools": "^1.0.14"
     },
     "scripts": {
         "build": "npx @superdesk/build-tools build-root-repo ./"


### PR DESCRIPTION
build tools used to throw an error when attempting to delete a directory that didn't exist. That may be a reason why translations aren't available.