### PR TITLE
[SDCP-559] fix: Locations format in French News Events List

### DIFF
--- a/server/cp/planning_exports/common.py
+++ b/server/cp/planning_exports/common.py
@@ -142,11 +142,13 @@ def set_item_location(item, event):
     if item["address"]["name"]:
         item["address"]["name"] = item["address"]["name"].upper()
 
-    if item["address"]["full"]:
-        item["address"]["full"] = ". " + item["address"]["full"]
-
     if item["address"]["title"] and item["address"]["address"]:
         item["address"]["short"] = item["address"]["title"] + ", " + item["address"]["address"]
+    else:
+        item["address"]["short"] = item["address"]["full"]
+
+    if item["address"]["full"]:
+        item["address"]["full"] = ". " + item["address"]["full"]
 
 
 def set_item_coverages(item):

--- a/server/templates/french_news_events_list_export.html
+++ b/server/templates/french_news_events_list_export.html
@@ -14,7 +14,7 @@
                     COUVERTURE: {{ item.coverage_types }}.<br>
                 {%- endif -%}
                 {%- if item.address.city -%}
-                    {{ item.address.city }} - {{ item.local_time }}.{{ item.address.short }}.
+                    {{ item.address.city }} - {{ item.local_time }}. {{ item.address.short }}.
                 {%- else -%}
                     {{ item.local_time }}.
                 {%- endif -%}


### PR DESCRIPTION
Fixes the following reported format problems:
* There is no space between `Time` of the event and the `Location`
* When the Event's `Location` is does not have an `Address`, there are 2 dots after the event's location