### PR TITLE
[SDCP-593] fix AP: Don't map sluglines to subjects

### DIFF
--- a/server/cp/ingest/parser/ap.py
+++ b/server/cp/ingest/parser/ap.py
@@ -851,6 +851,10 @@ class CP_APMediaFeedParser(APMediaFeedParser):
             for p in products
         ])
 
+    def categorisation_mapping(self, in_item, item):
+        """Avoid extra mapping."""
+        pass
+
 
 def append_matching_subject(item, scheme, qcode):
     cv_items = _get_cv_items(scheme)


### PR DESCRIPTION
This has already been overridden in `develop` branch, but looks like it's causing issues with certain slugs:
See:

- https://github.com/superdesk/superdesk-core/blob/develop/superdesk/io/feed_parsers/ap_media.py#L58
- https://github.com/superdesk/superdesk-core/blob/develop/superdesk/io/feed_parsers/ap_media.py#L161

