### PR TITLE
fix find query with version_creator

### DIFF
--- a/server/cp/macros/auto_routing.py
+++ b/server/cp/macros/auto_routing.py
@@ -65,10 +65,15 @@ def callback(item, **kwargs):
         superdesk.get_resource_service("archive")
         .find(
             where={
-                "uri": item["uri"],
-                "version_creator": {"$nin": [None, ""]},  # only consider updated by user
-                "state": {"$ne": CONTENT_STATE.SPIKED},
-            },
+                "$and": [
+                    {"uri": item["uri"]},
+                    # can't use $nin, looks like bug in eve
+                    # converting [None, ""] to [ObjectId(), ""]
+                    {"version_creator": {"$ne": None}},
+                    {"version_creator": {"$ne": ""}},
+                    {"state": {"$ne": CONTENT_STATE.SPIKED}},
+                ],
+            },  # type: ignore
             max_results=1,
         )
         .sort("versioncreated", -1)


### PR DESCRIPTION
seems like error in eve, it was converting None
when there was $nin query with list.

SDCP-537