### PR TITLE
fix wrong grouping of transcripts

### DIFF
--- a/server/cp/ingest/parser/cp_transcripts.py
+++ b/server/cp/ingest/parser/cp_transcripts.py
@@ -1,23 +1,6 @@
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
-from superdesk import get_resource_service
 from superdesk.io.feed_parsers.ninjs import NINJSFeedParser
-
-
-def get_previous_version(
-    original_ingest_id: str, version_number: int
-) -> Optional[Dict[str, Any]]:
-    while version_number >= 0:
-        ingest_id = f"{original_ingest_id}.{version_number}"
-        prev_item = get_resource_service("archive").find_one(
-            req=None, ingest_id=ingest_id
-        )
-
-        if prev_item is not None:
-            return prev_item
-        version_number -= 1
-
-    return None
 
 
 class CPTranscriptsFeedParser(NINJSFeedParser):
@@ -43,7 +26,8 @@ class CPTranscriptsFeedParser(NINJSFeedParser):
             )
         )
 
-        previous_item = get_previous_version(original_guid, version - 1)
-        if previous_item is not None:
-            item["rewrite_of"] = previous_item["ingest_id"]
+        if version > 0:
+            # set it as expected not based on what already arrived
+            item["rewrite_of"] = f"{original_guid}.{version-1}"
+
         return item

--- a/server/tests/ingest/parser/cp_transcripts.py
+++ b/server/tests/ingest/parser/cp_transcripts.py
@@ -19,17 +19,9 @@ class CP_Transcripts_ParseTestCase(unittest.TestCase):
 
     def test_parse(self):
         with self.app.app_context(), patch.dict(superdesk.resources, resources):
-            superdesk.resources["archive"].service.find_one.side_effect = [
-                {
-                    "ingest_id": "d3c8487a-1757-4dde-8bb5-22ca166c1e67.0",
-                    "version": 0,
-                    "extra": {"ap_version": 999},
-                },
-            ]
             items = parser.parse(
                 get_fixture_path("cp_transcripts.json", "cp_transcripts"), provider
             )
-            superdesk.resources["archive"].service.find_one.side_effect = None
 
         item = items[0]
         self.assertEqual("text", item["type"])


### PR DESCRIPTION
we were setting the ancestors based on what already arrived but if there would be a delay it would create multiple versions using the same previous version and then it creates multiple groups in newshub.

SDCP-767