### PR TITLE
fix globenewswire language

### DIFF
--- a/server/cp/ingest/parser/globenewswire.py
+++ b/server/cp/ingest/parser/globenewswire.py
@@ -11,13 +11,13 @@ SOURCE = "Globenewswire"
 KEYWORD_ROLE = "MWKeyRole:Ticker"
 
 DESCRIPTION = {
-    "en": "Press Release",
-    "fr": "Communiqué",
+    "en-CA": "Press Release",
+    "fr-CA": "Communiqué",
 }
 
 BODY_FOOTER = {
-    "en": "NEWS RELEASE TRANSMITTED BY Globe Newswire",
-    "fr": "COMMUNIQUE DE PRESSE TRANSMIS PAR Globe Newswire",
+    "en-CA": "NEWS RELEASE TRANSMITTED BY Globe Newswire",
+    "fr-CA": "COMMUNIQUE DE PRESSE TRANSMIS PAR Globe Newswire",
 }
 
 NS = {
@@ -80,11 +80,11 @@ class GlobeNewswireParser(NewsMLTwoFeedParser):
     def parse_content_meta(self, tree, item):
         meta = super().parse_content_meta(tree, item)
 
-        item["language"] = item["language"].split("-")[0]
+        item["language"] = "{}-CA".format(item["language"].split("-")[0])
         item["description_text"] = DESCRIPTION[item["language"]]
 
         item["slugline"] = "GNW-{lang}-{time}--{symbols}".format(
-            lang=item["language"],
+            lang=item["language"].split("-")[0],
             time=meta.find(self.qname("contentCreated")).text[17:19],
             symbols="-".join(self._get_stock_symbols(tree)),
         )

--- a/server/tests/ingest/parser/globenewswire_test.py
+++ b/server/tests/ingest/parser/globenewswire_test.py
@@ -19,7 +19,7 @@ class GlobeNewswireParserTestCase(ParserTestCase):
         self.assertIsNotNone(item)
 
         self.assertIsNone(item.get("byline"))
-        self.assertEqual("en", item["language"])
+        self.assertEqual("en-CA", item["language"])
         self.assertEqual("usable", item["pubstatus"])
         self.assertEqual("GNW-en-10--AXL", item["slugline"])
         self.assertEqual(["TSX VENTURE:AXL", "OTC:NTGSF"], item["keywords"])
@@ -63,7 +63,7 @@ class GlobeNewswireParserTestCase(ParserTestCase):
     def test_fr(self):
         item = self.parse("fr.xml")
         self.assertIsNotNone(item)
-        self.assertEqual("fr", item["language"])
+        self.assertEqual("fr-CA", item["language"])
         self.assertEqual("Communiqué", item["description_text"])
 
         item["unique_id"] = 1

--- a/server/tests/output/formatter/jimi_test.py
+++ b/server/tests/output/formatter/jimi_test.py
@@ -191,7 +191,7 @@ class JimiFormatterTestCase(BaseXmlFormatterTestCase):
                 "keywords": ["TSX VENTURE:AXL", "OTC:NTGSF"],
                 "anpa_category": [
                     {
-                        "name": globenewswire.DESCRIPTION["en"],
+                        "name": globenewswire.DESCRIPTION["en-CA"],
                         "qcode": "p",
                     }
                 ],


### PR DESCRIPTION
add `-CA` to it so it matches languages used in vocabularies

SDCP-819