### PR TITLE
[SDCP-1031] - Image uploaded to body_html or feature media does not remove the upload dialogue at the end

### DIFF
--- a/client/extensions/upload-iptc/src/extension.ts
+++ b/client/extensions/upload-iptc/src/extension.ts
@@ -38,18 +38,20 @@ const copySubj = (scheme: string) => (subj: ISubject) => ({
     source: '',
 });
 
-const toString = (value: string | Array<string> | undefined) : string => (
-    Array.isArray(value) ? value[0] : (value || '')
-);
+const toString = (value: string | Array<string> | undefined): string =>
+    String(Array.isArray(value) ? value?.[0] ?? '' : value ?? '');
 
-const toArray = (value: string | Array<string> | undefined) : Array<string> => {
+const toArray = (value: string | Array<string> | undefined): Array<string> => {
     if (value == null) {
         return [];
     }
 
-    return (Array.isArray(value) ? value : value.split('\n'))
-        .map((value) => value.trim());
-}
+    const ensureStringArray = Array.isArray(value) ? value : value.split('\n');
+
+    return ensureStringArray
+        .map((entry) => String(entry ?? ''))
+        .map((entry) => entry.trim());
+};
 
 const extension: IExtension = {
     activate: (superdesk: ISuperdesk) => {


### PR DESCRIPTION
### Purpose
This PR updates the helper functions `toString` and `toArray` to better handle metadata when it is processed and arrives as a number/array which was causing an error downstream on the UI at this [part](https://github.com/superdesk/superdesk-client-core/pull/5020)

### How to test
1. Upload media where slugline is mapped to a number from `object_name` like the image attached below.
2. It should save without issues or errors on the console. It shouldn't stay stuck on the Upload dialogue.

Sample photo to use 
![picture](https://github.com/user-attachments/assets/2c70a3d3-dfad-44b9-95d3-55d46eb8a3b0)


Issue - [SDCP-1031](https://sofab.atlassian.net/browse/SDCP-1031)

[SDCP-1031]: https://sofab.atlassian.net/browse/SDCP-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ