### PR TITLE
[SDCP-1045] fix: NINJS2.1 using incorrect subscriber generate_sequence_number call

### DIFF
--- a/server/cp/output/formatter/ninjs_21_formatter.py
+++ b/server/cp/output/formatter/ninjs_21_formatter.py
@@ -4,9 +4,8 @@ import logging
 import re
 from typing import Tuple, Dict
 
-from flask import current_app as app
-from eve.utils import config
 from superdesk.publish.formatters import Formatter
+from superdesk.publish_async.utils import generate_sequence_number
 from superdesk.errors import FormatterError
 from superdesk.metadata.item import (
     ITEM_TYPE,
@@ -190,11 +189,9 @@ class NINJS21Formatter(Formatter):
 
         return self._infosources_cache
 
-    def format(self, article, subscriber, codes=None):
+    async def format(self, article, subscriber, codes=None):
         try:
-            pub_seq_num = superdesk.get_resource_service(
-                "subscribers"
-            ).generate_sequence_number(subscriber)
+            pub_seq_num = await generate_sequence_number(subscriber)
 
             ninjs = self._transform_to_ninjs(article, subscriber)
             return [


### PR DESCRIPTION
### Purpose
The `NINJS2.1` was raising an exception as it was using the old `Subscribers` resource from the Eve library, which no longer exists (only the newer Pydantic based resource exists for this resource).

### What has changed
Use `generate_sequence_number` async publish util instead of the subscribers resource

Resolves: [SDCP-1045](https://sofab.atlassian.net/browse/SDCP-1045)

[SDCP-1045]: https://sofab.atlassian.net/browse/SDCP-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ