### PR TITLE
[SDCP-1063] fix: Ultrad aiohttp timeout param

### DIFF
--- a/server/cp/ultrad.py
+++ b/server/cp/ultrad.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 ULTRAD_ID = "ultrad_id"
 ULTRAD_URL = "https://pc-trad.herokuapp.com/cms/"
-ULTRAD_TIMEOUT = (5, 15)
+ULTRAD_TIMEOUT = aiohttp.ClientTimeout(total=15, connect=3)
 
 IN_PROGRESS_STATES = [
     CONTENT_STATE.ROUTED,


### PR DESCRIPTION
### Purpose
When upgrading to async we now use the `aiohttp` library instead of the `requests` library. This library's timeout param required a different value type.

### What has changed
Use the `ClientTimeout` type from `aiohttp`.

Resolves: [SDCP-1063](https://sofab.atlassian.net/browse/SDCP-1063)

[SDCP-1063]: https://sofab.atlassian.net/browse/SDCP-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ