### PR TITLE
[SDCP-1125] fix(ultrad): API Response in HTML not JSON

### DIFF
--- a/server/cp/ultrad.py
+++ b/server/cp/ultrad.py
@@ -32,7 +32,7 @@ class UltradException(RuntimeError):
 
 
 def get_headers():
-    return {"x-ultrad-auth": app.config["ULTRAD_AUTH"]}
+    return {"Accept": "application/json", "x-ultrad-auth": app.config["ULTRAD_AUTH"]}
 
 
 async def upload_document(item: dict) -> str | None:


### PR DESCRIPTION
### Purpose
The Ultrad service is providing the response in HTML format, meanwhile our code expects json.

### What has changed:
* Add `Accept: application/json` to headers

Resolves: [SDCP-1125](https://sofab.atlassian.net/browse/SDCP-1125)

[SDCP-1125]: https://sofab.atlassian.net/browse/SDCP-1125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ