### PR TITLE
[SDCP-1119] fix(archiveSearch): Rename find to find_async

### DIFF
--- a/server/cp/archive_search.py
+++ b/server/cp/archive_search.py
@@ -103,7 +103,7 @@ class ArchiveSearchProvider(SearchProvider):
         except (ValueError, TypeError):
             return None
 
-    def find(self, query=None, params=None):
+    async def find_async(self, query=None, params=None):
         logger.info("Frontend query=%s params=%s", query, params)
 
         if query is None:


### PR DESCRIPTION
### Purpose
The `Archive Search` provider is not working with the newer async search provider core changes.

### What has changed
* Rename `find` method to `find_async`.

Note: This change isn't actually making the code use asyncio/http requests, but merely implements the interface expected in core.
Resolves: [SDCP-1119](https://sofab.atlassian.net/browse/SDCP-1119)

[SDCP-1119]: https://sofab.atlassian.net/browse/SDCP-1119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ