### PR TITLE
[SDCP-1126] fix(ninjs): KeyError raised on accessing subject

### DIFF
--- a/server/cp/output/formatter/cp_ninjs_newsroom_formatter.py
+++ b/server/cp/output/formatter/cp_ninjs_newsroom_formatter.py
@@ -58,6 +58,7 @@ class CPNewsroomNinjsFormatter(NewsroomNinjsFormatter):
                 if item.get("in_jimi") is True:
                     vocab_mapping[name_in_vocab.lower()] = (qcode, translated_name)
 
+            ninjs.setdefault("subject", [])
             updated_subjects = list(ninjs["subject"])
             # Setting a Pre defined Allowed Scheme Vocabulary Mapping
 

--- a/server/cp/output/formatter/ninjs_formatter_2.py
+++ b/server/cp/output/formatter/ninjs_formatter_2.py
@@ -650,6 +650,7 @@ class NINJSFormatter_2(Formatter):
                     )
                     vocab_mapping[name_in_vocab.lower()] = (qcode, translated_name)
 
+            ninjs.setdefault("subject", [])
             updated_subjects = list(ninjs["subject"])
 
             for subject in ninjs["subject"]:


### PR DESCRIPTION
### Purpose
Custom NinJS formatters are raising a KeyError for the `subject` field.

### What has changed
Use `setdefault` to make sure the `subject` has a value

Resolves: [SDCP-1126](https://sofab.atlassian.net/browse/SDCP-1126)

[SDCP-1126]: https://sofab.atlassian.net/browse/SDCP-1126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ