### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: "CI"
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   server:


### PR DESCRIPTION
Potential fix for [https://github.com/superdesk/superdesk-cp/security/code-scanning/5](https://github.com/superdesk/superdesk-cp/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/tests.yml` so all jobs inherit least-privilege defaults.  
Best single fix without changing functionality: set minimal read-only token scope for this CI workflow:

- `contents: read` (needed by most CI actions for checkout/repo reads)

Place it directly under the `on:` section (before `jobs:`). This preserves current workflow logic while ensuring `GITHUB_TOKEN` is explicitly restricted.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
