### PR TITLE
SDCP-1206: Add missing export() override to NINJSFormatter_2

### DIFF
--- a/server/cp/output/formatter/ninjs_formatter_2.py
+++ b/server/cp/output/formatter/ninjs_formatter_2.py
@@ -196,10 +196,12 @@ class NINJSFormatter_2(Formatter):
 
     async def export(self, item):
         if self.can_format(self.type, item):
-            sequence, formatted_doc = (await self.format(item, None, None))[0]
+            _, formatted_doc = (await self.format(item, None, None))[0]
             return formatted_doc.replace("''", "'")
         else:
-            raise Exception()
+            raise FormatterError.ninjsFormatterError(
+                Exception("Item type '{}' does not match formatter type '{}'".format(item.get("type"), self.type))
+            )
 
     # Adding a method to fetch Parents of Manual Tags
 

--- a/server/cp/output/formatter/ninjs_formatter_2.py
+++ b/server/cp/output/formatter/ninjs_formatter_2.py
@@ -194,6 +194,13 @@ class NINJSFormatter_2(Formatter):
         except Exception as ex:
             raise FormatterError.ninjsFormatterError(ex, subscriber)
 
+    async def export(self, item):
+        if self.can_format(self.type, item):
+            sequence, formatted_doc = (await self.format(item, None, None))[0]
+            return formatted_doc.replace("''", "'")
+        else:
+            raise Exception()
+
     # Adding a method to fetch Parents of Manual Tags
 
     async def _add_parent_manual_tags(self, item):

--- a/server/cp/output/formatter/ninjs_formatter_2.py
+++ b/server/cp/output/formatter/ninjs_formatter_2.py
@@ -200,7 +200,11 @@ class NINJSFormatter_2(Formatter):
             return formatted_doc.replace("''", "'")
         else:
             raise FormatterError.ninjsFormatterError(
-                Exception("Item type '{}' does not match formatter type '{}'".format(item.get("type"), self.type))
+                Exception(
+                    "Item type '{}' does not match formatter type '{}'".format(
+                        item.get("type"), self.type
+                    )
+                )
             )
 
     # Adding a method to fetch Parents of Manual Tags

--- a/server/tests/output/formatter/test_ninjs_formatter_2.py
+++ b/server/tests/output/formatter/test_ninjs_formatter_2.py
@@ -1,6 +1,11 @@
+import json
+from unittest.mock import patch, AsyncMock
+
+import superdesk
 from superdesk.tests import TestCase
 
 from cp.output.formatter.ninjs_formatter_2 import NINJSFormatter_2
+from tests.mock import resources, SEQUENCE_NUMBER
 
 
 class TestNinjsFormatter(TestCase):
@@ -25,3 +30,28 @@ class TestNinjsFormatter(TestCase):
 
         result = await self.formatter._get_associations(article, {})
         self.assertEqual(result, expected_result)
+
+    @patch(
+        "cp.output.formatter.ninjs_formatter_2.generate_sequence_number",
+        new_callable=AsyncMock,
+        return_value=SEQUENCE_NUMBER,
+    )
+    async def test_export_text_article(self, mock_generate_sequence_number):
+        article = {
+            "_id": "test-id",
+            "guid": "test-guid",
+            "type": "text",
+            "headline": "Test headline",
+            "body_html": "<p>Test body</p>",
+            "language": "en-CA",
+        }
+
+        with patch.dict(superdesk.resources, resources):
+            result = await self.formatter.export(article)
+
+        self.assertIsInstance(result, str)
+        parsed = json.loads(result)
+        self.assertEqual(parsed["guid"], "test-guid")
+        self.assertEqual(parsed["type"], "text")
+        self.assertEqual(parsed["headline"], "Test headline")
+        self.assertEqual(parsed["body_html"], "<p>Test body</p>")


### PR DESCRIPTION
### Purpose
This PR adds a missing `export()` override in the `NINJSFormatter_2` formatter. The export service calls export(item) with only one arg, causing a TypeError that crashed the request with a 500 which means no download URL was generated, so the browser showed a blank tab or download error.

NOTE: The blank tab / "can't be downloaded securely" issue on UAT could also be caused by `PREFERRED_URL_SCHEME` defaulting to "http" but since the frontend is HTTPS, it triggers a mixed content blocking. This should be set to "https" in the UAT deployment config.

Resolves:
1. [SDCP-1206](https://sofab.atlassian.net/browse/SDCP-1206)
2. [Sentry Issue](https://sentry2.sourcefabric.org/organizations/sourcefabric/issues/82885/?project=5&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20export&referrer=issue-stream&statsPeriod=14d&stream_index=4)

[SDCP-1206]: https://sofab.atlassian.net/browse/SDCP-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ