### PR TITLE
Enable async celery worker

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -504,3 +504,5 @@ DEFAULT_AUTHOR_FR = "cpdefaultauthorfr"
 HTTP_PUSH_TIMEOUT = (5, int(env("HTTP_PUSH_TIMEOUT", 60)))
 
 COPY_ON_REWRITE_FIELDS = ["event"]
+
+CELERY_USE_ASYNC_WORKER = True


### PR DESCRIPTION
### Purpose
Enable the async Celery worker on CP by setting `CELERY_USE_ASYNC_WORKER = True`

### What has changed
- `server/settings.py`: add `CELERY_USE_ASYNC_WORKER = True`.
